### PR TITLE
Add `--bug-report` CLI option to `kmxwasm.property`

### DIFF
--- a/kmxwasm/src/kmxwasm/build.py
+++ b/kmxwasm/src/kmxwasm/build.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from pyk.kbuild.kbuild import KBuild
 from pyk.kbuild.project import Project
+from pyk.utils import BugReport
 
 from .timing import Timer
 from .tools import Tools
@@ -12,7 +13,9 @@ LLVM_LIBRARY = 'llvm-library'
 LEMMA_PROOFS = 'lemma-proofs'
 
 
-def kbuild_semantics(output_dir: Path, config_file: Path, target: str, booster: bool) -> Tools:
+def kbuild_semantics(
+    output_dir: Path, config_file: Path, target: str, booster: bool, bug_report: BugReport | None
+) -> Tools:
     kbuild = KBuild(output_dir)
     package = Project.load(config_file)
 
@@ -34,4 +37,5 @@ def kbuild_semantics(output_dir: Path, config_file: Path, target: str, booster: 
         llvm_definition_dir=kbuild.definition_dir(package, LLVM),
         llvm_library_definition_dir=kbuild.definition_dir(package, LLVM_LIBRARY) if booster else None,
         booster=booster,
+        bug_report=bug_report,
     )

--- a/kmxwasm/src/kmxwasm/lemmas/generate.py
+++ b/kmxwasm/src/kmxwasm/lemmas/generate.py
@@ -255,7 +255,9 @@ def main(args: list[str]) -> None:
     LEMMAS_FILE.write_text('```k\nmodule PROVEN-MX-LEMMAS\nendmodule\n```\n')
     HELPER_LEMMAS_FILE.write_text('```k\nmodule HELPER-LEMMAS\nendmodule\n```\n')
 
-    with kbuild_semantics(KBUILD_DIR, config_file=KBUILD_ML_PATH, target=LEMMA_PROOFS, booster=False) as tools:
+    with kbuild_semantics(
+        KBUILD_DIR, config_file=KBUILD_ML_PATH, target=LEMMA_PROOFS, booster=False, bug_report=None
+    ) as tools:
         for lemma in LEMMAS:
             definition = lemma.make_definition()
             printed = tools.printer.pretty_print(definition)
@@ -270,7 +272,9 @@ def main(args: list[str]) -> None:
         printed_helper = tools.printer.pretty_print(helper_module)
         HELPER_LEMMAS_FILE.write_text('```k\n' + cleanup(printed_helper) + '\n```\n')
 
-    with kbuild_semantics(KBUILD_DIR, config_file=KBUILD_ML_PATH, target=LEMMA_PROOFS, booster=False) as tools:
+    with kbuild_semantics(
+        KBUILD_DIR, config_file=KBUILD_ML_PATH, target=LEMMA_PROOFS, booster=False, bug_report=None
+    ) as tools:
         tools.printer
 
 

--- a/kmxwasm/src/kmxwasm/testing/fixtures.py
+++ b/kmxwasm/src/kmxwasm/testing/fixtures.py
@@ -9,5 +9,7 @@ from ..tools import Tools
 @pytest.fixture(scope='session')
 def tools(tmp_path_factory: TempPathFactory) -> Tools:
     build_path = tmp_path_factory.mktemp('kbuild')
-    tools = kbuild_semantics(output_dir=build_path, config_file=KBUILD_ML_PATH, target=HASKELL, booster=True)
+    tools = kbuild_semantics(
+        output_dir=build_path, config_file=KBUILD_ML_PATH, target=HASKELL, booster=True, bug_report=None
+    )
     return tools

--- a/kmxwasm/src/kmxwasm/tools.py
+++ b/kmxwasm/src/kmxwasm/tools.py
@@ -14,7 +14,7 @@ from pyk.ktool.krun import KRunOutput, _krun
 from pyk.prelude.k import GENERATED_TOP_CELL
 from pyk.utils import BugReport
 
-USE_BUG_REPORT = False
+# USE_BUG_REPORT = False
 
 
 class Tools:
@@ -23,11 +23,13 @@ class Tools:
         definition_dir: Path,
         llvm_definition_dir: Path | None,
         llvm_library_definition_dir: Path | None,
+        bug_report: BugReport | None,
         booster: bool,
     ) -> None:
         self.__definition_dir = definition_dir
         self.__llvm_definition_dir = llvm_definition_dir
         self.__llvm_library_definition_dir = llvm_library_definition_dir
+        self.__bug_report = bug_report
         self.__booster = booster
         self.__kprove: Optional[KProve] = None
         self.__explorer: Optional[KCFGExplore] = None
@@ -59,9 +61,6 @@ class Tools:
 
     @property
     def explorer(self) -> KCFGExplore:
-        bug_report = None
-        if USE_BUG_REPORT:
-            bug_report = BugReport(Path('bug-report'))
         if not self.__kore_server:
             if self.__kore_client:
                 raise RuntimeError('Non-null KoreClient with null KoreServer.')
@@ -73,17 +72,18 @@ class Tools:
                     self.printer.main_module,
                     command=('kore-rpc-booster'),
                     # command=('kore-rpc-booster', '-l', 'Rewrite'),
-                    bug_report=bug_report
+                    bug_report=self.__bug_report
                     # port=39425,
                 )
             else:
                 self.__kore_server = KoreServer(
                     self.__definition_dir,
                     self.printer.main_module,
+                    bug_report=self.__bug_report
                     # port=39425,
                 )
         if not self.__kore_client:
-            self.__kore_client = KoreClient('localhost', self.__kore_server.port, bug_report=bug_report)
+            self.__kore_client = KoreClient('localhost', self.__kore_server.port, bug_report=self.__bug_report)
 
         if not self.__explorer:
             self.__explorer = KCFGExplore(self.printer, self.__kore_client)


### PR DESCRIPTION
This PR brings `kmxwasm`'s Haskell backend bug report generation facilities up-to-date. 

An example call
```
poetry run python3 -m src.kmxwasm.property \
    --claim src/tests/integration/data/test_call_add_less-spec.json \
    --kcfg=../.property/kcfg.json \
    --booster --bug-report bug_report
```

Will generate the `bug_report.tar` file in the current directory, with the following contents:
```
bug_report.tar
├── definition.kore
├── llvm_definition
│   ├── definition.kore
│   └── dt
├── rpc_140159221966800
│   ├── 001_request.json
│   ├── 001_response.json
│   ├── 002_request.json
│   ├── 002_response.json
│   ├── 003_request.json
│   ├── 003_response.json
│   ├── 004_request.json
│   ├── 004_response.json
│   ├── 005_request.json
│   ├── 005_response.json
│   ├── 006_request.json
│   ├── 006_response.json
│   ├── 007_request.json
│   ├── 007_response.json
│   ├── 008_request.json
│   ├── 008_response.json
│   ├── 009_request.json
│   ├── 009_response.json
│   ├── 010_request.json
│   ├── 010_response.json
│   ├── 011_request.json
│   ├── 011_response.json
│   ├── 012_request.json
│   └── 012_response.json
├── server_instance.json
└── server_version.txt
```