### PR TITLE
Add push to binary cache on master push

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,0 +1,28 @@
+name: 'Master Push'
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+
+  nix-binary-cache:
+    name: 'Populate Nix Binary Cache'
+    strategy:
+      matrix:
+        runner: [normal, MacIntel, ARM64]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+
+      - name: 'Publish kmxwasm to k-framework-binary cache'
+        uses: workflow/nix-shell-action@v3
+        env:
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
+          GC_DONT_GC: '1'
+        with:
+          packages: jq
+          script: |
+            export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
+            kup publish k-framework-binary .#kmxwasm --keep-days 180


### PR DESCRIPTION
Seeing as the kmxwasm binaries take a lot of resources to build locally, we should build and publish them in the binary cache.